### PR TITLE
Fix #13 and OOP-related improvements

### DIFF
--- a/src/main/java/io/github/seggan/sfcalc/CalcCommand.java
+++ b/src/main/java/io/github/seggan/sfcalc/CalcCommand.java
@@ -61,7 +61,7 @@ public class CalcCommand extends AbstractCommand {
 
         SFCalcMetrics.addItemSearched(item.getItemName());
 
-        Calculator.printResults(sender, item, amount, false);
+        SFCalc.inst().getCalc().printResults(sender, item, amount, false);
     }
 
     @Override

--- a/src/main/java/io/github/seggan/sfcalc/CalcCommand.java
+++ b/src/main/java/io/github/seggan/sfcalc/CalcCommand.java
@@ -61,8 +61,7 @@ public class CalcCommand extends AbstractCommand {
 
         SFCalcMetrics.addItemSearched(item.getItemName());
 
-        Calculator calculator = new Calculator(SFCalc.inst().getBlacklistedRecipes(), SFCalc.inst().getBlacklistedIds());
-        calculator.printResults(sender, item, amount, false);
+        Calculator.printResults(sender, item, amount, false);
     }
 
     @Override

--- a/src/main/java/io/github/seggan/sfcalc/CalcCommand.java
+++ b/src/main/java/io/github/seggan/sfcalc/CalcCommand.java
@@ -12,12 +12,15 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 
+import static io.github.seggan.sfcalc.StringRegistry.format;
+
 public class CalcCommand extends AbstractCommand {
-
     private static final List<String> ids = new ArrayList<>();
+    private SFCalc plugin;
 
-    public CalcCommand() {
+    public CalcCommand(SFCalc pl) {
         super("calc", "Calculates the resources needed for a given item", false);
+        this.plugin = pl;
     }
 
     @Override
@@ -26,7 +29,7 @@ public class CalcCommand extends AbstractCommand {
         String reqItem;
         SlimefunItem item;
 
-        StringRegistry registry = SFCalc.inst().getStringRegistry();
+        StringRegistry registry = plugin.getStringRegistry();
 
         if (args.length > 3 || args.length < 2) {
             return;
@@ -37,17 +40,17 @@ public class CalcCommand extends AbstractCommand {
         if (args.length == 2) {
             amount = 1;
         } else if (!PatternUtils.NUMERIC.matcher(args[2]).matches()) {
-            sender.sendMessage(registry.getNotANumberString());
+            sender.sendMessage(format(registry.getNotANumberString()));
             return;
         } else {
             try {
                 amount = Long.parseLong(args[2]);
                 if (amount == 0 || amount > Integer.MAX_VALUE) {
-                    sender.sendMessage(registry.getInvalidNumberString());
+                    sender.sendMessage(format(registry.getInvalidNumberString()));
                     return;
                 }
             } catch (NumberFormatException e) {
-                sender.sendMessage(registry.getInvalidNumberString());
+                sender.sendMessage(format(registry.getInvalidNumberString()));
                 return;
             }
         }
@@ -55,13 +58,13 @@ public class CalcCommand extends AbstractCommand {
         item = SlimefunItem.getByID(reqItem.toUpperCase(Locale.ROOT));
 
         if (item == null) {
-            sender.sendMessage(registry.getNoItemString());
+            sender.sendMessage(format(registry.getNoItemString()));
             return;
         }
 
         SFCalcMetrics.addItemSearched(item.getItemName());
 
-        SFCalc.inst().getCalc().printResults(sender, item, amount, false);
+        plugin.getCalc().printResults(sender, item, amount, false);
     }
 
     @Override

--- a/src/main/java/io/github/seggan/sfcalc/Calculator.java
+++ b/src/main/java/io/github/seggan/sfcalc/Calculator.java
@@ -29,7 +29,6 @@ import static io.github.seggan.sfcalc.StringRegistry.format;
  */
 public class Calculator {
     private SFCalc plugin;
-    private final Map<Pair<ItemStack, Long>, Map<ItemStack, Long>> calculated = new HashMap<>();
 
     public Calculator(SFCalc pl) {
         this.plugin = pl;

--- a/src/main/java/io/github/seggan/sfcalc/Calculator.java
+++ b/src/main/java/io/github/seggan/sfcalc/Calculator.java
@@ -128,7 +128,7 @@ public class Calculator {
         SlimefunItemStack next = getNextItem(result);
         while(next != null) {
             int multiplier = next.getItem().getRecipeOutput().getAmount();
-            Long operations = (result.get(next)+multiplier-1)/multiplier; //ceiling(needed/multiplier) but abusing fast ints
+            long operations = (result.get(next)+multiplier-1)/multiplier; //ceiling(needed/multiplier) but abusing fast ints
             add(result, next, -(multiplier*operations));
             for(ItemStack item : next.getItem().getRecipe()) {
                 if(item == null) continue;

--- a/src/main/java/io/github/seggan/sfcalc/Calculator.java
+++ b/src/main/java/io/github/seggan/sfcalc/Calculator.java
@@ -26,9 +26,12 @@ import static io.github.seggan.sfcalc.StringRegistry.format;
  * @author TheBusyBiscuit
  */
 public class Calculator {
+    private SFCalc plugin;
+    private final Map<Pair<ItemStack, Long>, Map<ItemStack, Long>> calculated = new HashMap<>();
 
-    private final static Map<Pair<ItemStack, Long>, Map<ItemStack, Long>> calculated = new HashMap<>();
-
+    public Calculator(SFCalc pl) {
+        this.plugin = pl;
+    }
     /**
      * Calculates the resources for the item and prints the out to the specified {@link CommandSender}
      *
@@ -38,10 +41,10 @@ public class Calculator {
      * @param needed whether it should print out how many are needed. Requires {@code sender instanceof Player}
      * to be {@code true}
      */
-    public static void printResults(@Nonnull CommandSender sender, @Nonnull SlimefunItem item, long amount, boolean needed) {
+    public void printResults(@Nonnull CommandSender sender, @Nonnull SlimefunItem item, long amount, boolean needed) {
         Map<ItemStack, Long> results = calculate(item, amount);
 
-        StringRegistry registry = SFCalc.inst().getStringRegistry();
+        StringRegistry registry = plugin.getStringRegistry();
 
         String header;
         String name = getBasicName(item.getItem());
@@ -89,7 +92,7 @@ public class Calculator {
     }
 
     @Nonnull
-    private static Map<ItemStack, Long> getInventoryAsItemList(@Nonnull Player player) {
+    private Map<ItemStack, Long> getInventoryAsItemList(@Nonnull Player player) {
         Map<ItemStack, Long> inv = new HashMap<>();
 
         for (ItemStack item : player.getInventory().getContents()) {
@@ -105,7 +108,7 @@ public class Calculator {
     }
 
     @Nonnull
-    public static Map<ItemStack, Long> calculate(@Nonnull SlimefunItem parent, Long amount) {
+    public Map<ItemStack, Long> calculate(@Nonnull SlimefunItem parent, Long amount) {
         //check cache
         if(calculated.containsKey(new Pair<>(parent.getItem(), amount))) {
             return calculated.get(new Pair<>(parent.getItem(), amount));
@@ -146,12 +149,12 @@ public class Calculator {
      * @return
      */
     @Nullable
-    private static SlimefunItemStack getNextItem(Map<ItemStack, Long> map) {
+    private SlimefunItemStack getNextItem(Map<ItemStack, Long> map) {
         for(Map.Entry<ItemStack, Long> entry : map.entrySet()) {
             if(entry.getKey() instanceof SlimefunItemStack) {
                 SlimefunItemStack ingredient = (SlimefunItemStack)entry.getKey();
-                if (!SFCalc.getBlacklistedIds().contains(ingredient.getItemId()) &&
-                        !SFCalc.getBlacklistedRecipes().contains(ingredient.getItem().getRecipeType())) {
+                if (!plugin.getBlacklistedIds().contains(ingredient.getItemId()) &&
+                        !plugin.getBlacklistedRecipes().contains(ingredient.getItem().getRecipeType())) {
                     if(entry.getValue() > 0) {
                         return ingredient;
                     }
@@ -161,18 +164,18 @@ public class Calculator {
         return null;
     }
 
-    private static void add(@Nonnull Map<ItemStack, Long> map, @Nonnull ItemStack key, long amount) {
+    private void add(@Nonnull Map<ItemStack, Long> map, @Nonnull ItemStack key, long amount) {
         map.merge(key, amount, Long::sum);
     }
 
-    private static void addAll(@Nonnull Map<ItemStack, Long> map, @Nonnull Map<ItemStack, Long> otherMap, long multiplier) {
+    private void addAll(@Nonnull Map<ItemStack, Long> map, @Nonnull Map<ItemStack, Long> otherMap, long multiplier) {
         for (Map.Entry<ItemStack, Long> entry : otherMap.entrySet()) {
             add(map, entry.getKey(), entry.getValue() * multiplier);
         }
     }
 
     @Nonnull
-    private static String getBasicName(ItemStack stack) {
+    private String getBasicName(ItemStack stack) {
         return ChatColor.stripColor(ItemUtils.getItemName(stack));
     }
 }

--- a/src/main/java/io/github/seggan/sfcalc/Calculator.java
+++ b/src/main/java/io/github/seggan/sfcalc/Calculator.java
@@ -27,11 +27,9 @@ import static io.github.seggan.sfcalc.StringRegistry.format;
  * @author Seggan
  * @author TheBusyBiscuit
  */
-@AllArgsConstructor
 public class Calculator {
 
-    private final Set<RecipeType> blacklistedRecipes;
-    private final Set<String> blacklistedIds;
+    private final static Map<ItemStack, Map<ItemStack, Long>> calculated = new HashMap<>();
 
     /**
      * Calculates the resources for the item and prints the out to the specified {@link CommandSender}
@@ -42,7 +40,7 @@ public class Calculator {
      * @param needed whether it should print out how many are needed. Requires {@code sender instanceof Player}
      * to be {@code true}
      */
-    public void printResults(@Nonnull CommandSender sender, @Nonnull SlimefunItem item, long amount, boolean needed) {
+    public static void printResults(@Nonnull CommandSender sender, @Nonnull SlimefunItem item, long amount, boolean needed) {
         Map<ItemStack, Long> results = calculate(item);
 
         StringRegistry registry = SFCalc.inst().getStringRegistry();
@@ -92,7 +90,7 @@ public class Calculator {
     }
 
     @Nonnull
-    private Map<ItemStack, Long> getInventoryAsItemList(@Nonnull Player player) {
+    private static Map<ItemStack, Long> getInventoryAsItemList(@Nonnull Player player) {
         Map<ItemStack, Long> inv = new HashMap<>();
 
         for (ItemStack item : player.getInventory().getContents()) {
@@ -108,9 +106,8 @@ public class Calculator {
     }
 
     @Nonnull
-    public Map<ItemStack, Long> calculate(@Nonnull SlimefunItem item) {
+    public static Map<ItemStack, Long> calculate(@Nonnull SlimefunItem item) {
         Map<ItemStack, Long> result = new HashMap<>();
-        Map<ItemStack, Map<ItemStack, Long>> calculated = new HashMap<>(); // stores names that are already calculated for reference
 
         for (ItemStack i : item.getRecipe()) {
             if (i == null) {
@@ -139,10 +136,10 @@ public class Calculator {
                     continue;
                 }
 
-                if (blacklistedIds.contains(ingredient.getId())) {
+                if (SFCalc.getBlacklistedIds().contains(ingredient.getId())) {
                     // it's a blacklisted item
                     add(recipe, i, 1);
-                } else if (blacklistedRecipes.contains(ingredient.getRecipeType())) {
+                } else if (SFCalc.getBlacklistedRecipes().contains(ingredient.getRecipeType())) {
                     // item is a dust or a geo miner resource; just add it
                     add(recipe, i, 1);
                 } else {
@@ -158,11 +155,11 @@ public class Calculator {
         return result;
     }
 
-    private void add(@Nonnull Map<ItemStack, Long> map, @Nonnull ItemStack key, long amount) {
+    private static void add(@Nonnull Map<ItemStack, Long> map, @Nonnull ItemStack key, long amount) {
         map.merge(key, amount, Long::sum);
     }
 
-    private void addAll(@Nonnull Map<ItemStack, Long> map, @Nonnull Map<ItemStack, Long> otherMap, long multiplier) {
+    private static void addAll(@Nonnull Map<ItemStack, Long> map, @Nonnull Map<ItemStack, Long> otherMap, long multiplier) {
         for (Map.Entry<ItemStack, Long> entry : otherMap.entrySet()) {
             add(map, entry.getKey(), entry.getValue() * multiplier);
         }

--- a/src/main/java/io/github/seggan/sfcalc/Calculator.java
+++ b/src/main/java/io/github/seggan/sfcalc/Calculator.java
@@ -16,6 +16,7 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.logging.Level;
 
 import static io.github.seggan.sfcalc.StringRegistry.format;
 
@@ -65,7 +66,9 @@ public class Calculator {
 
             for (Map.Entry<ItemStack, Long> entry : entries) {
                 Long inInventory = inv.getOrDefault(entry.getKey(), 0L);
-                long a = entry.getValue() * amount - inInventory;
+                if(entry.getValue() <= 0) continue; //intermediate product/byproduct
+                long a = entry.getValue() - inInventory;
+                if(a < 0) a = 0;
                 String parsedAmount;
                 int maxStackSize = entry.getKey().getMaxStackSize();
                 if (a <= maxStackSize) {
@@ -100,7 +103,6 @@ public class Calculator {
             if (item == null || item.getType().isAir()) {
                 continue;
             }
-
             add(inv, item, item.getAmount());
         }
 
@@ -165,7 +167,9 @@ public class Calculator {
     }
 
     private void add(@Nonnull Map<ItemStack, Long> map, @Nonnull ItemStack key, long amount) {
-        map.merge(key, amount, Long::sum);
+        ItemStack clone = key.clone();
+        clone.setAmount(1);
+        map.merge(clone, amount, Long::sum);
     }
 
     private void addAll(@Nonnull Map<ItemStack, Long> map, @Nonnull Map<ItemStack, Long> otherMap, long multiplier) {

--- a/src/main/java/io/github/seggan/sfcalc/Calculator.java
+++ b/src/main/java/io/github/seggan/sfcalc/Calculator.java
@@ -66,7 +66,7 @@ public class Calculator {
                 Map<ItemStack, Long> inv = getInventoryAsItemList((Player) sender);
 
                 for (Map.Entry<ItemStack, Long> entry : entries) {
-                    Long inInventory = inv.getOrDefault(entry.getKey(), 0L);
+                    long inInventory = inv.getOrDefault(entry.getKey(), 0L);
                     if(entry.getValue() <= 0) continue; //intermediate product/byproduct
                     long a = entry.getValue() - inInventory;
                     if(a < 0) a = 0;

--- a/src/main/java/io/github/seggan/sfcalc/Calculator.java
+++ b/src/main/java/io/github/seggan/sfcalc/Calculator.java
@@ -112,7 +112,7 @@ public class Calculator {
     }
 
     @Nonnull
-    public Map<ItemStack, Long> calculate(@Nonnull SlimefunItem parent, Long amount) {
+    public Map<ItemStack, Long> calculate(@Nonnull SlimefunItem parent, long amount) {
 
         Map<ItemStack, Long> result = new HashMap<>();
         add(result, parent.getItem(), amount);

--- a/src/main/java/io/github/seggan/sfcalc/NeededCommand.java
+++ b/src/main/java/io/github/seggan/sfcalc/NeededCommand.java
@@ -67,8 +67,7 @@ public class NeededCommand extends AbstractCommand {
 
         SFCalcMetrics.addItemSearched(item.getItemName());
 
-        Calculator calculator = new Calculator(SFCalc.inst().getBlacklistedRecipes(), SFCalc.inst().getBlacklistedIds());
-        calculator.printResults(sender, item, amount, true);
+        Calculator.printResults(sender, item, amount, true);
     }
 
     @Override

--- a/src/main/java/io/github/seggan/sfcalc/NeededCommand.java
+++ b/src/main/java/io/github/seggan/sfcalc/NeededCommand.java
@@ -13,12 +13,15 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 
+import static io.github.seggan.sfcalc.StringRegistry.format;
+
 public class NeededCommand extends AbstractCommand {
-
     private static final List<String> ids = new ArrayList<>();
+    private SFCalc plugin;
 
-    public NeededCommand() {
+    public NeededCommand(SFCalc pl) {
         super("needed", "Tells you how much more resources are needed", false);
+        this.plugin = pl;
     }
 
     @Override
@@ -27,10 +30,10 @@ public class NeededCommand extends AbstractCommand {
         String reqItem;
         SlimefunItem item;
 
-        StringRegistry registry = SFCalc.inst().getStringRegistry();
+        StringRegistry registry = plugin.getStringRegistry();
 
         if (!(sender instanceof Player)) {
-            sender.sendMessage(registry.getNotAPlayerString());
+            sender.sendMessage(format(registry.getNotAPlayerString()));
             return;
         }
 
@@ -43,17 +46,17 @@ public class NeededCommand extends AbstractCommand {
         if (args.length == 2) {
             amount = 1;
         } else if (!PatternUtils.NUMERIC.matcher(args[2]).matches()) {
-            sender.sendMessage(registry.getNotANumberString());
+            sender.sendMessage(format(registry.getNotANumberString()));
             return;
         } else {
             try {
                 amount = Long.parseLong(args[2]);
                 if (amount == 0 || amount > Integer.MAX_VALUE) {
-                    sender.sendMessage(registry.getInvalidNumberString());
+                    sender.sendMessage(format(registry.getInvalidNumberString()));
                     return;
                 }
             } catch (NumberFormatException e) {
-                sender.sendMessage(registry.getInvalidNumberString());
+                sender.sendMessage(format(registry.getInvalidNumberString()));
                 return;
             }
         }
@@ -61,13 +64,13 @@ public class NeededCommand extends AbstractCommand {
         item = SlimefunItem.getByID(reqItem.toUpperCase());
 
         if (item == null) {
-            sender.sendMessage(registry.getNoItemString());
+            sender.sendMessage(format(registry.getNoItemString()));
             return;
         }
 
         SFCalcMetrics.addItemSearched(item.getItemName());
 
-        SFCalc.inst().getCalc().printResults(sender, item, amount, true);
+        plugin.getCalc().printResults(sender, item, amount, true);
     }
 
     @Override

--- a/src/main/java/io/github/seggan/sfcalc/NeededCommand.java
+++ b/src/main/java/io/github/seggan/sfcalc/NeededCommand.java
@@ -67,7 +67,7 @@ public class NeededCommand extends AbstractCommand {
 
         SFCalcMetrics.addItemSearched(item.getItemName());
 
-        Calculator.printResults(sender, item, amount, true);
+        SFCalc.inst().getCalc().printResults(sender, item, amount, true);
     }
 
     @Override

--- a/src/main/java/io/github/seggan/sfcalc/SFCalc.java
+++ b/src/main/java/io/github/seggan/sfcalc/SFCalc.java
@@ -12,7 +12,9 @@ import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.plugin.java.JavaPlugin;
 
 import javax.annotation.Nonnull;
+import java.util.Collection;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.Set;
 
 @Getter
@@ -28,7 +30,6 @@ public class SFCalc extends JavaPlugin implements SlimefunAddon, Listener {
     @Override
     public void onEnable() {
         instance = this;
-        calculator = new Calculator(this);
 
         PluginUtils.setup("SFCalc", this, "Seggan/SFCalc/master", getFile());
         PluginUtils.setupMetrics(8812);
@@ -36,6 +37,7 @@ public class SFCalc extends JavaPlugin implements SlimefunAddon, Listener {
         CommandManager.setup("sfcalc", "/sfc", new CalcCommand(this), new NeededCommand(this));
 
         stringRegistry = new StringRegistry();
+        calculator = new Calculator(this);
 
         blacklistedRecipes.add(RecipeType.ORE_WASHER);
         blacklistedRecipes.add(RecipeType.GEO_MINER);
@@ -55,13 +57,6 @@ public class SFCalc extends JavaPlugin implements SlimefunAddon, Listener {
     @Override
     public JavaPlugin getJavaPlugin() {
         return this;
-    }
-
-    public Set<RecipeType> getBlacklistedRecipes() {
-        return blacklistedRecipes;
-    }
-    public Set<String> getBlacklistedIds() {
-        return blacklistedIds;
     }
 
     @Override

--- a/src/main/java/io/github/seggan/sfcalc/SFCalc.java
+++ b/src/main/java/io/github/seggan/sfcalc/SFCalc.java
@@ -33,7 +33,7 @@ public class SFCalc extends JavaPlugin implements SlimefunAddon, Listener {
         PluginUtils.setup("SFCalc", this, "Seggan/SFCalc/master", getFile());
         PluginUtils.setupMetrics(8812);
 
-        CommandManager.setup("sfcalc", "/sfc", new CalcCommand(), new NeededCommand());
+        CommandManager.setup("sfcalc", "/sfc", new CalcCommand(this), new NeededCommand(this));
 
         stringRegistry = new StringRegistry();
 

--- a/src/main/java/io/github/seggan/sfcalc/SFCalc.java
+++ b/src/main/java/io/github/seggan/sfcalc/SFCalc.java
@@ -14,14 +14,11 @@ import org.bukkit.plugin.java.JavaPlugin;
 import javax.annotation.Nonnull;
 import java.util.HashSet;
 import java.util.Set;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 @Getter
 public class SFCalc extends JavaPlugin implements SlimefunAddon, Listener {
 
     private static SFCalc instance;
-    private Logger log;
 
     private final static Set<RecipeType> blacklistedRecipes = new HashSet<>();
     private final static Set<String> blacklistedIds = new HashSet<>();
@@ -31,7 +28,6 @@ public class SFCalc extends JavaPlugin implements SlimefunAddon, Listener {
     @Override
     public void onEnable() {
         instance = this;
-        log = getLogger();
 
         PluginUtils.setup("SFCalc", this, "Seggan/SFCalc/master", getFile());
         PluginUtils.setupMetrics(8812);
@@ -82,8 +78,5 @@ public class SFCalc extends JavaPlugin implements SlimefunAddon, Listener {
         if (e.getPlayer().isOp() && stringRegistry.getAmountString().contains("%s")) {
             e.getPlayer().sendMessage(ChatColor.RED + "[SFCalc] Hey, I see you are using outdated SFCalc config! For SFCalc to work properly, please delete config.yml and restart the server");
         }
-    }
-    public void log(String str) {
-        log.log(Level.INFO, str);
     }
 }

--- a/src/main/java/io/github/seggan/sfcalc/SFCalc.java
+++ b/src/main/java/io/github/seggan/sfcalc/SFCalc.java
@@ -20,8 +20,8 @@ public class SFCalc extends JavaPlugin implements SlimefunAddon, Listener {
 
     private static SFCalc instance;
 
-    private final Set<RecipeType> blacklistedRecipes = new HashSet<>();
-    private final Set<String> blacklistedIds = new HashSet<>();
+    private final static Set<RecipeType> blacklistedRecipes = new HashSet<>();
+    private final static Set<String> blacklistedIds = new HashSet<>();
 
     private StringRegistry stringRegistry;
 
@@ -47,12 +47,20 @@ public class SFCalc extends JavaPlugin implements SlimefunAddon, Listener {
         blacklistedIds.add("UU_MATTER");
         blacklistedIds.add("SILICON");
         blacklistedIds.add("FALLEN_METEOR");
+
     }
 
     @Nonnull
     @Override
     public JavaPlugin getJavaPlugin() {
         return this;
+    }
+
+    public static Set<RecipeType> getBlacklistedRecipes() {
+        return blacklistedRecipes;
+    }
+    public static Set<String> getBlacklistedIds() {
+        return blacklistedIds;
     }
 
     @Override

--- a/src/main/java/io/github/seggan/sfcalc/SFCalc.java
+++ b/src/main/java/io/github/seggan/sfcalc/SFCalc.java
@@ -14,11 +14,14 @@ import org.bukkit.plugin.java.JavaPlugin;
 import javax.annotation.Nonnull;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 @Getter
 public class SFCalc extends JavaPlugin implements SlimefunAddon, Listener {
 
     private static SFCalc instance;
+    private Logger log;
 
     private final static Set<RecipeType> blacklistedRecipes = new HashSet<>();
     private final static Set<String> blacklistedIds = new HashSet<>();
@@ -28,6 +31,7 @@ public class SFCalc extends JavaPlugin implements SlimefunAddon, Listener {
     @Override
     public void onEnable() {
         instance = this;
+        log = getLogger();
 
         PluginUtils.setup("SFCalc", this, "Seggan/SFCalc/master", getFile());
         PluginUtils.setupMetrics(8812);
@@ -78,5 +82,8 @@ public class SFCalc extends JavaPlugin implements SlimefunAddon, Listener {
         if (e.getPlayer().isOp() && stringRegistry.getAmountString().contains("%s")) {
             e.getPlayer().sendMessage(ChatColor.RED + "[SFCalc] Hey, I see you are using outdated SFCalc config! For SFCalc to work properly, please delete config.yml and restart the server");
         }
+    }
+    public void log(String str) {
+        log.log(Level.INFO, str);
     }
 }

--- a/src/main/java/io/github/seggan/sfcalc/SFCalc.java
+++ b/src/main/java/io/github/seggan/sfcalc/SFCalc.java
@@ -17,17 +17,18 @@ import java.util.Set;
 
 @Getter
 public class SFCalc extends JavaPlugin implements SlimefunAddon, Listener {
-
     private static SFCalc instance;
+    private Calculator calculator;
 
-    private final static Set<RecipeType> blacklistedRecipes = new HashSet<>();
-    private final static Set<String> blacklistedIds = new HashSet<>();
+    private final Set<RecipeType> blacklistedRecipes = new HashSet<>();
+    private final Set<String> blacklistedIds = new HashSet<>();
 
     private StringRegistry stringRegistry;
 
     @Override
     public void onEnable() {
         instance = this;
+        calculator = new Calculator(this);
 
         PluginUtils.setup("SFCalc", this, "Seggan/SFCalc/master", getFile());
         PluginUtils.setupMetrics(8812);
@@ -56,10 +57,10 @@ public class SFCalc extends JavaPlugin implements SlimefunAddon, Listener {
         return this;
     }
 
-    public static Set<RecipeType> getBlacklistedRecipes() {
+    public Set<RecipeType> getBlacklistedRecipes() {
         return blacklistedRecipes;
     }
-    public static Set<String> getBlacklistedIds() {
+    public Set<String> getBlacklistedIds() {
         return blacklistedIds;
     }
 
@@ -71,6 +72,10 @@ public class SFCalc extends JavaPlugin implements SlimefunAddon, Listener {
     @Nonnull
     static SFCalc inst() {
         return instance;
+    }
+
+    public Calculator getCalc() {
+        return calculator;
     }
 
     @EventHandler


### PR DESCRIPTION
instead of creating a new Calculator instance every time someone wants to calculate something, just have it be a static class since a Calculator isn't mutable. also kept blacklistedRecipes and blacklistedIds in SFCalc.java since it's only used once so there's no need to store it in the Calculator. the cache is now also implemented in the correct scope(global). finally, the calculation is restructured so that the items you make are stored in a simulated inventory, which fixes #13.