### PR TITLE
[Fix] Fix NPE introduced with the Hidden Item Fix

### DIFF
--- a/src/main/java/io/github/seggan/sfcalc/CalcCommand.java
+++ b/src/main/java/io/github/seggan/sfcalc/CalcCommand.java
@@ -74,13 +74,15 @@ public class CalcCommand implements TabExecutor {
         SFCalc.REPORTER.executeOrElseReport(() -> {
             if (ids.isEmpty()) {
                 for (SlimefunItem item : Slimefun.getRegistry().getEnabledSlimefunItems()) {
-                    ids.add(item.getId().toLowerCase(Locale.ROOT));
+                    if (!item.isHidden()) {
+                        ids.add(item.getId().toLowerCase(Locale.ROOT));
+                    }
                 }
             }
 
             if (args.length == 1) {
                 for (String id : ids) {
-                    if (id.contains(args[0].toLowerCase(Locale.ROOT)) && !SlimefunItem.getById(id).isHidden()) {
+                    if (id.contains(args[0].toLowerCase(Locale.ROOT))) {
                         tabs.add(id);
                     }
                 }


### PR DESCRIPTION
## Description
Because of how you did the hidden item fix, if the player hasn't finished typing out the id, it will produce an NPE, which is 99% of the time (only way to get around it afaik would be to paste in the portion of the command). 

## Changes
- Moves where you check if the item is hidden to the initialization of `ids`

## Related Issues
- Resolves #31 